### PR TITLE
Añade checkbox para anonimizar notificaciones en el plugin action/messageagent

### DIFF
--- a/action/messageagent/lang/en/notificationsaction_messageagent.php
+++ b/action/messageagent/lang/en/notificationsaction_messageagent.php
@@ -42,3 +42,5 @@ $string['editrule_action_message'] = 'Message {$a->typeelement}';
 $string['subtype'] = 'messageagent';
 $string['messageagent_event'] = 'Message agent';
 $string['privacy:metadata'] = 'The messageagent plugin does not store any personal data.';
+$string['editrule_action_anonymize'] = 'Anonymize';
+$string['editrule_action_anonymize_help'] = "Mark this option to send the message from the system instead of from the rule owner.";

--- a/action/messageagent/lang/es/notificationsaction_messageagent.php
+++ b/action/messageagent/lang/es/notificationsaction_messageagent.php
@@ -42,3 +42,5 @@ $string['editrule_action_message'] = 'Mensaje {$a->typeelement}';
 $string['subtype'] = 'messageagent';
 $string['messageagent_event'] = 'Agente de mensajería';
 $string['privacy:metadata'] = 'El plugin de messageagent no almacena ningún dato personal.';
+$string['editrule_action_anonymize'] = 'Anonimizar';
+$string['editrule_action_anonymize_help'] = "Marca esta opción para enviar este mensaje desde el sistema en vez de desde el propietario de la regla.";

--- a/action/messageagent/tests/messageagent_test.php
+++ b/action/messageagent/tests/messageagent_test.php
@@ -33,6 +33,7 @@
 
 namespace notificationsaction_messageagent;
 
+use core_user;
 use Generator;
 use local_notificationsagent\evaluationcontext;
 use local_notificationsagent\form\editrule_form;
@@ -129,11 +130,14 @@ class messageagent_test extends \advanced_testcase {
      * @dataProvider dataprovider
      */
     public function test_execute_action($param, $user) {
+        $this->preventResetByRollback();
+
         $auxarray = json_decode($param, true);
+        $msg_is_anonymous = $auxarray['anonymize'];
         self::$context->set_params($param);
         self::$context->set_rule(self::$rule);
         self::$context->set_userid(self::$user->id);
-        self::$context->set_courseid(self::$coursecontext->id);
+        self::$context->set_courseid(self::$coursetest->id);
         self::$context->set_usertimesfired(1);
         self::$subplugin->set_id(self::CONDITIONID);
         self::$rule->set_createdby($user === 0 ? self::$user->id : $user);
@@ -145,8 +149,9 @@ class messageagent_test extends \advanced_testcase {
         $this->assertCount(1, $messages);
         $this->assertIsInt($result);
         $this->assertSame(self::$user->email, $messages[0]->to);
-        if ($user !== 0) {
-            $this->assertStringContainsString('Admin', $messages[0]->subject);
+        if ($user !== 0 && !$msg_is_anonymous) {
+            $userfrom = core_user::get_user($user);
+            $this->assertStringContainsString(fullname($userfrom), $messages[0]->subject);
         } else {
             $this->assertStringContainsString($auxarray['title'], $messages[0]->subject);
         }
@@ -158,8 +163,9 @@ class messageagent_test extends \advanced_testcase {
      */
     public static function dataprovider(): array {
         return [
-                ['{"title":"TEST","message":"Message body"}', 2],
-                ['{"title":"TEST","message":"Message body"}', 0],
+                ['{"title":"TEST","message":"Message body","anonymize":false}', 2],
+                ['{"title":"TEST","message":"Message body","anonymize":true}', 2],
+                ['{"title":"TEST","message":"Message body","anonymize":false}', 0],
         ];
     }
 
@@ -268,9 +274,11 @@ class messageagent_test extends \advanced_testcase {
         $method = phpunitutil::get_method(self::$subplugin, 'get_name_ui');
         $uititlename = $method->invoke(self::$subplugin, self::$subplugin::UI_TITLE);
         $uiamessagename = $method->invoke(self::$subplugin, self::$subplugin::UI_MESSAGE);
+        $uianonymizename = $method->invoke(self::$subplugin, self::$subplugin::UI_ANONYMIZE);
 
         $this->assertTrue($mform->elementExists($uititlename));
         $this->assertTrue($mform->elementExists($uiamessagename));
+        $this->assertTrue($mform->elementExists($uianonymizename));
     }
 
     /**
@@ -311,6 +319,8 @@ class messageagent_test extends \advanced_testcase {
 
         // Format message text // delete ['text'].
         $auxarray['message'] = $auxarray[self::$subplugin::UI_MESSAGE]['text'];
+        // anonymize should default to false if it's not set
+        $auxarray['anonymize'] = isset($auxarray[self::$subplugin::UI_ANONYMIZE]);
 
         self::$subplugin->set_parameters($param);
         $actual = self::$subplugin->get_parameters_placeholders();


### PR DESCRIPTION
Añade un checkbox en el formulario de la acción de messageagent que "anonimiza" el mensaje para que la notificación se envíe desde el sistema en vez de desde el propietario de la regla.

Esto permite enviar mensajes que salgan en las notificaciones de Moodle del sistema (la "campana") en vez de que salgan siempre en una conversación, que no me parece apropiado para todos los casos.