### PR TITLE
Bypass observers for disabled conditions Disabled subplugins does not disable observers. #139

### DIFF
--- a/classes/plugininfo/notificationscondition.php
+++ b/classes/plugininfo/notificationscondition.php
@@ -109,7 +109,16 @@ class notificationscondition extends notificationsbaseinfo {
 
         return $haschanged;
     }
-
+    /**
+     * Get the enablement status of the plugin.
+     * @param string $pluginname The name of the plugin to check.
+     * @return bool True if the plugin is enabled, false otherwise.
+     */
+    public static function is_plugin_enabled(string $pluginname): bool {
+        $plugin = 'notificationscondition_' . $pluginname;
+        $disabled = get_config($plugin, 'disabled');
+        return !$disabled;
+    }
     /**
      * Return URL used for management of plugins of this type.
      *

--- a/condition/ac/classes/observer.php
+++ b/condition/ac/classes/observer.php
@@ -48,7 +48,10 @@ class notificationscondition_ac_observer {
      */
     public static function group_deleted(\core\event\group_deleted $event) {
         global $DB;
-
+        // Bypass the event hadler if the plugin is disabled.
+        if (! local_notificationsagent\plugininfo\notificationscondition::is_plugin_enabled(ac::NAME)) {
+            return;
+        }
         $sql = 'SELECT mnc.id, mnc.ruleid AS ruleid
                   FROM {notificationsagent_condition} mnc
                  WHERE mnc.pluginname = :name';

--- a/condition/activitycompleted/classes/observer.php
+++ b/condition/activitycompleted/classes/observer.php
@@ -49,7 +49,10 @@ class notificationscondition_activitycompleted_observer {
         $pluginname = activitycompleted::NAME;
         $courseid = $event->courseid;
         $userid = $event->relateduserid;
-
+        // Bypass the event hadler if the plugin is disabled.
+        if (! local_notificationsagent\plugininfo\notificationscondition::is_plugin_enabled($pluginname)) {
+            return;
+        }
         $conditions = notificationsagent::get_conditions_by_cm($pluginname, $courseid, $event->contextinstanceid);
 
         if ($event->other['completionstate'] == COMPLETION_INCOMPLETE) {

--- a/condition/activityend/classes/observer.php
+++ b/condition/activityend/classes/observer.php
@@ -51,7 +51,10 @@ class notificationscondition_activityend_observer {
         $cmid = $event->objectid;
 
         $pluginname = activityend::NAME;
-
+        // Bypass the event hadler if the plugin is disabled.
+        if (! local_notificationsagent\plugininfo\notificationscondition::is_plugin_enabled($pluginname)) {
+            return;
+        }
         $conditions = notificationsagent::get_conditions_by_cm($pluginname, $courseid, $cmid);
 
         foreach ($conditions as $condition) {

--- a/condition/activitymodified/classes/observer.php
+++ b/condition/activitymodified/classes/observer.php
@@ -46,6 +46,10 @@ class notificationscondition_activitymodified_observer {
      * @param \core\event\course_module_updated $event The course module update event.
      */
     public static function course_module_updated(\core\event\course_module_updated $event) {
+        // Bypass the event handler if the plugin is disabled.
+        if (!local_notificationsagent\plugininfo\notificationscondition::is_plugin_enabled(activitymodified::NAME)) {
+            return;
+        }
         if (has_capability('moodle/course:managefiles', \context_course::instance($event->courseid), $event->userid)) {
             $pluginname = activitymodified::NAME;
             $conditions = notificationsagent::get_conditions_by_cm($pluginname, $event->courseid, $event->objectid);

--- a/condition/activitynewcontent/classes/observer.php
+++ b/condition/activitynewcontent/classes/observer.php
@@ -48,6 +48,10 @@ class notificationscondition_activitynewcontent_observer {
      * @return void
      */
     public static function course_module_created(\core\event\course_module_created $event) {
+        // Bypass the event handler if the plugin is disabled.
+        if (!local_notificationsagent\plugininfo\notificationscondition::is_plugin_enabled(activitynewcontent::NAME)) {
+            return;
+        }
         $other = $event->other;
         $namemodule = $other["modulename"];
         if (in_array($namemodule, activitynewcontent::UNUSED_TYPES)) {

--- a/condition/activityopen/classes/observer.php
+++ b/condition/activityopen/classes/observer.php
@@ -48,11 +48,13 @@ class notificationscondition_activityopen_observer {
      * @param \core\event\course_module_updated $event The course module update event.
      */
     public static function course_module_updated(\core\event\course_module_updated $event) {
+        $pluginname = activityopen::NAME;
+        // Bypass the event hadler if the plugin is disabled.
+        if (!local_notificationsagent\plugininfo\notificationscondition::is_plugin_enabled($pluginname)) {
+            return;
+        }
         $courseid = $event->courseid;
         $cmid = $event->objectid;
-
-        $pluginname = activityopen::NAME;
-
         $conditions = notificationsagent::get_conditions_by_cm($pluginname, $courseid, $cmid);
         foreach ($conditions as $condition) {
             $subplugin = new activityopen($condition->ruleid, $condition->id);

--- a/condition/activitysinceend/classes/observer.php
+++ b/condition/activitysinceend/classes/observer.php
@@ -47,6 +47,10 @@ class notificationscondition_activitysinceend_observer {
      */
     public static function course_module_completion_updated(\core\event\course_module_completion_updated $event) {
         $pluginname = activitysinceend::NAME;
+        // Bypass the event handler if the plugin is disabled.
+        if (!local_notificationsagent\plugininfo\notificationscondition::is_plugin_enabled($pluginname)) {
+            return;
+        }
         $courseid = $event->courseid;
         $userid = $event->relateduserid;
 

--- a/condition/activitystudentend/classes/observer.php
+++ b/condition/activitystudentend/classes/observer.php
@@ -48,12 +48,15 @@ class notificationscondition_activitystudentend_observer {
      * @param course_module_viewed $event Course module viewed event
      */
     public static function course_module_viewed(course_module_viewed $event) {
+        $pluginname = activitystudentend::NAME;
+        // Bypass the event handler if the plugin is disabled.
+        if (!local_notificationsagent\plugininfo\notificationscondition::is_plugin_enabled($pluginname)) {
+            return;
+        }
         $courseid = $event->courseid;
         $cmid = $event->contextinstanceid;
         $userid = $event->userid;
         $timecreated = $event->timecreated;
-
-        $pluginname = activitystudentend::NAME;
 
         activitystudentend::set_activity_access($userid, $courseid, $cmid, $timecreated);
 

--- a/condition/calendareventto/classes/observer.php
+++ b/condition/calendareventto/classes/observer.php
@@ -52,6 +52,11 @@ class notificationscondition_calendareventto_observer {
      * @return void
      */
     public static function calendar_updated(core\event\calendar_event_updated $event) {
+        $pluginname = calendareventto::NAME;
+        // Bypass the event handler if the plugin is disabled.
+        if (!local_notificationsagent\plugininfo\notificationscondition::is_plugin_enabled($pluginname)) {
+            return;
+        }
         $other = $event->other;
 
         // If startdate is not set in other array then the startdate setting has not been modified.
@@ -59,7 +64,6 @@ class notificationscondition_calendareventto_observer {
             return;
         }
 
-        $pluginname = calendareventto::NAME;
         $cmid = $event->objectid;
         $courseid = $event->courseid;
 

--- a/condition/calendarstart/classes/observer.php
+++ b/condition/calendarstart/classes/observer.php
@@ -52,6 +52,10 @@ class notificationscondition_calendarstart_observer {
      */
     public static function calendar_updated(calendar_event_updated $event) {
         $pluginname = calendarstart::NAME;
+        // Bypass the event handler if the plugin is disabled.
+        if (!local_notificationsagent\plugininfo\notificationscondition::is_plugin_enabled($pluginname)) {
+            return;
+        }
         $cmid = $event->objectid;
         $courseid = $event->courseid;
 

--- a/condition/courseend/classes/observer.php
+++ b/condition/courseend/classes/observer.php
@@ -47,6 +47,11 @@ class notificationscondition_courseend_observer {
      * @param core\event\course_updated $event The course_updated event object
      */
     public static function course_updated(core\event\course_updated $event) {
+        $pluginname = courseend::NAME;
+        // Bypass the event handler if the plugin is disabled.
+        if (!local_notificationsagent\plugininfo\notificationscondition::is_plugin_enabled($pluginname)) {
+            return;
+        }
         if ($event->courseid == 1) {
             return null;
         }
@@ -62,7 +67,6 @@ class notificationscondition_courseend_observer {
         // Save cache.
         helper::set_cache_course($courseid);
 
-        $pluginname = courseend::NAME;
         $conditions = notificationsagent::get_conditions_by_course($pluginname, $courseid);
         foreach ($conditions as $condition) {
             $subplugin = new courseend($condition->ruleid, $condition->id);

--- a/condition/coursestart/classes/observer.php
+++ b/condition/coursestart/classes/observer.php
@@ -48,6 +48,11 @@ class notificationscondition_coursestart_observer {
      * @return null|void Returns null if the courseid is 1, otherwise does not return anything
      */
     public static function course_updated(\core\event\course_updated $event) {
+        $pluginname = coursestart::NAME;
+        // Bypass the event handler if the plugin is disabled.
+        if (!local_notificationsagent\plugininfo\notificationscondition::is_plugin_enabled($pluginname)) {
+            return;
+        }
         if ($event->courseid == 1) {
             return null;
         }
@@ -62,7 +67,6 @@ class notificationscondition_coursestart_observer {
         // Save cache.
         helper::set_cache_course($courseid);
 
-        $pluginname = coursestart::NAME;
         $conditions = notificationsagent::get_conditions_by_course($pluginname, $courseid);
         foreach ($conditions as $condition) {
             $subplugin = new coursestart($condition->ruleid, $condition->id);

--- a/condition/itemgraded/classes/observer.php
+++ b/condition/itemgraded/classes/observer.php
@@ -47,6 +47,10 @@ class notificationscondition_itemgraded_observer {
      */
     public static function user_graded($event) {
         $pluginname = itemgraded::NAME;
+        // Bypass the event handler if the plugin is disabled.
+        if (!local_notificationsagent\plugininfo\notificationscondition::is_plugin_enabled($pluginname)) {
+            return;
+        }
         $courseid = $event->courseid;
         $userid = $event->relateduserid;
 

--- a/condition/sessionend/classes/observer.php
+++ b/condition/sessionend/classes/observer.php
@@ -47,6 +47,11 @@ class notificationscondition_sessionend_observer {
      * @throws \dml_exception
      */
     public static function course_viewed(\core\event\course_viewed $event) {
+        $pluginname = sessionend::NAME;
+        // Bypass the event handler if the plugin is disabled.
+        if (!local_notificationsagent\plugininfo\notificationscondition::is_plugin_enabled($pluginname)) {
+            return;
+        }
         if ($event->courseid == SITEID || !isloggedin()) {
             return;
         }
@@ -55,7 +60,6 @@ class notificationscondition_sessionend_observer {
         $courseid = $event->courseid;
         $timeaccess = $event->timecreated;
 
-        $pluginname = sessionend::NAME;
         $conditions = notificationsagent::get_conditions_by_course($pluginname, $courseid);
         foreach ($conditions as $condition) {
             $subplugin = new sessionend($condition->ruleid, $condition->id);

--- a/condition/sessionstart/classes/observer.php
+++ b/condition/sessionstart/classes/observer.php
@@ -47,6 +47,11 @@ class notificationscondition_sessionstart_observer {
      * @param course_viewed $event The course_viewed event object
      */
     public static function course_viewed(course_viewed $event) {
+        $pluginname = sessionstart::NAME;
+        // Bypass the event hadler if the plugin is disabled.
+        if (! local_notificationsagent\plugininfo\notificationscondition::is_plugin_enabled($pluginname)) {
+            return;
+        }
         if ($event->courseid == SITEID || !isloggedin()) {
             return;
         }
@@ -63,7 +68,6 @@ class notificationscondition_sessionstart_observer {
         // We use this event to avoid querying the log_standard_log for a course firstaccess.
         sessionstart::set_first_course_access($userid, $courseid, $timeaccess);
 
-        $pluginname = sessionstart::NAME;
         $conditions = notificationsagent::get_conditions_by_course($pluginname, $courseid);
         foreach ($conditions as $condition) {
             $subplugin = new sessionstart($condition->ruleid, $condition->id);

--- a/condition/usergroupadd/classes/observer.php
+++ b/condition/usergroupadd/classes/observer.php
@@ -50,6 +50,10 @@ class notificationscondition_usergroupadd_observer {
      */
     public static function group_member_added(\core\event\group_member_added $event) {
         $pluginname = usergroupadd::NAME;
+        // Bypass the event handler if the plugin is disabled.
+        if (!local_notificationsagent\plugininfo\notificationscondition::is_plugin_enabled($pluginname)) {
+            return;
+        }
         $courseid = $event->courseid;
         $userid = $event->relateduserid;
         $groupid = $event->objectid;


### PR DESCRIPTION
About #139
Every observer is disabled if the subplugin is disabled.
TODO: Need to check this also in related scheduledtasks.