### PR TITLE
Refactoring of observer logic to bypass not needed triggers updates.

### DIFF
--- a/condition/activitystudentend/classes/observer.php
+++ b/condition/activitystudentend/classes/observer.php
@@ -55,9 +55,11 @@ class notificationscondition_activitystudentend_observer {
 
         $pluginname = activitystudentend::NAME;
 
-        activitystudentend::set_activity_access($userid, $courseid, $cmid, $timecreated);
-
         $conditions = notificationsagent::get_conditions_by_cm($pluginname, $courseid, $cmid);
+        
+        if (!empty($conditions)) {
+            activitystudentend::set_activity_access($userid, $courseid, $cmid, $timecreated);
+        }
 
         foreach ($conditions as $condition) {
             $conditionid = $condition->id;

--- a/condition/sessionstart/classes/observer.php
+++ b/condition/sessionstart/classes/observer.php
@@ -56,12 +56,13 @@ class notificationscondition_sessionstart_observer {
         $timeaccess = $event->timecreated;
         // Only triggered if is the first access to a course, otherwise return.
         $firstaccess = sessionstart::get_first_course_access($userid, $courseid);
-        if (!$firstaccess) {
+        if (!empty($firstaccess)) {
+            // If the first access is not empty, it means that the user has already accessed the course.
+            // So we do not need to updatetrigger the conditions.
             return null;
         }
-
-        // We use this event to avoid querying the log_standard_log for a course firstaccess.
-        sessionstart::set_first_course_access($userid, $courseid, $timeaccess);
+        // If the first access is empty, it means that the user has not accessed the course yet.
+        // So we need to update the triggers of the conditions.
 
         $pluginname = sessionstart::NAME;
         $conditions = notificationsagent::get_conditions_by_course($pluginname, $courseid);


### PR DESCRIPTION
Problema: Se ha detectado alta carga acumulada en un curso sin reglas activadas. Se diagnostica que está causado por las consultas innecesarias en los observer de eventos course_viewed y module_viewed.

Solución: minimizar las atualizaciones de triggers en los observers.

En este PR propongo unos cambios para que:
1) Se puentee el observer en caso de que el usuario ya haya sido registrado previamente. Esto implica que este código ya se ha ejecutado para él. Esta inicialización solo debe ejecutarse una vez para cada usuario y curso ¿es así?
2) La función get_first_course_access() incluye el cacheo del timestamp. Antes no había forma de saber si el timestampt devueto era el cacheado o el de mdl_log_store. Se podía dar el caso de hacer siempre la consulta a mdl_logstore que hay que evitar a toda costa.

Suposiciones de esta lógica:
a) El código del observer solo debe ejecutarse una vez por cada userid-courseid.
b) Las demás reconfiguraciones de los triggers se realizan con las operaciones de alta, baja y modificaciones de las reglas de forma estandar desde el motor de reglas.

Por favor, revisar.